### PR TITLE
Contract invariant example

### DIFF
--- a/examples/transitions/invariant.md
+++ b/examples/transitions/invariant.md
@@ -3,8 +3,6 @@
 ```act
 contract A
 
-storage
-
 	x : uint256
 
 invariants
@@ -13,27 +11,59 @@ invariants
 	x <= 1 {f, h}
 
 
+property f_post of f
+
+	pre(x) = 0 => post(x) = 1
+
+
+property g_post of g
+
+	pre(x) = 1 => post(x) = 2
+
+
+property h_post of h
+
+	pre(x) = 2 => post(x) = 0
+
+
 behavior f of A
 interface f()
 
+case x == 0:
+	x := 1
+
+case _:
+	noop
+
 ensures
 
-	x != 0
-
+	pre(x) = 0 => post(x) = 1
 
 
 behavior g of A
 interface g()
 
+case x == 1:
+	x := 2
+
+case _:
+	noop
+
 ensures
 
-	x != 1
+	pre(x) = 1 => post(x) = 2
 
 
 behavior h of A
 interface h()
 
+case x == 2:
+	x := 0
+
+case _:
+	noop
+
 ensures
 
-	x != 2
+	pre(x) = 2 => post(x) = 0
 ```

--- a/examples/transitions/invariant.md
+++ b/examples/transitions/invariant.md
@@ -1,0 +1,39 @@
+# Contract invariant, functions pre and post
+
+```act
+contract A
+
+storage
+
+	x : uint256
+
+invariants
+
+	x <= 2
+	x <= 1 {f, h}
+
+
+behavior f of A
+interface f()
+
+ensures
+
+	x != 0
+
+
+
+behavior g of A
+interface g()
+
+ensures
+
+	x != 1
+
+
+behavior h of A
+interface h()
+
+ensures
+
+	x != 2
+```

--- a/examples/transitions/invariant.sol
+++ b/examples/transitions/invariant.sol
@@ -1,0 +1,18 @@
+contract C {
+    uint x;
+  
+    function f() public {      
+        if (x == 0)
+            x = 1;             
+    }
+
+    function g() public {
+        if (x == 1)
+            x = 2;
+    }
+
+    function h() public {
+        if (x == 2)
+            x = 0;
+    }
+}


### PR DESCRIPTION
Consider the following contract written in Solidity:
```
contract C {
    uint x;
  
    function f() public {      
        if (x == 0)
            x = 1;             
    }

    function g() public {
        if (x == 1)
            x = 2;
    }

    function h() public {
        if (x == 2)
            x = 0;
    }
}
```

The added specification is an example of how to specify properties of this contract, with some things to discuss.

1. In this high level (no EVM) version of the specification language, I would suggest listing a contract's state variables in a `storage` section under a `contract`, where the types would match the ABI specification.
2. The state variables can then be used by the following function specifications without the need to specify a storage slot.
3. Contract invariants would be described in `invariants` also under `contract`. A property may hold over all functions, where the set of functions it holds for is not specified, or over a specified set of functions.
4. Each function can specify its post condition under `ensures`. Is this the same as the currently used `such that`?